### PR TITLE
Fix issues identified when attempting a test deployment

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ COPY helperscripts /telegraf/helperscripts
 RUN mkdir -p /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger && cp src/friendlytagger.go /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger/
 RUN sed -i '8i\        _ "github.com/influxdata/telegraf/plugins/processors/friendlytagger"' /go/src/github.com/influxdata/telegraf/plugins/processors/all/all.go
 
-RUN cd /go/src/github.com/influxdata/telegraf/ && make go-install
+RUN cd /go/src/github.com/influxdata/telegraf/ && make && go install -ldflags "-w -s" ./cmd/telegraf
 RUN cd helperscripts && go build -o /go/bin/queryasnnames .
 
 FROM alpine:latest

--- a/helperscripts/queryasnnames.go
+++ b/helperscripts/queryasnnames.go
@@ -69,7 +69,7 @@ func LoadAsnNames(pageid int32, db *sql.DB) bool {
 
     var ctx context.Context
 
-    url := fmt.Sprintf("https://api.panda.caida.org/as2org/dev/asns/?verbose=true&page=%d", pageid)
+    url := fmt.Sprintf("https://api.data.caida.org/as2org/dev/asns/?verbose=true&page=%d", pageid)
 
     client := http.Client{ Timeout: time.Second * 10}
 

--- a/src/README.md
+++ b/src/README.md
@@ -23,7 +23,7 @@ Make sure ${GOROOT} is set -- default is usually `/usr/local/go`
     cp friendlytagger.go ${GOROOT}/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger/
     sed -i '8i\        _ "github.com/influxdata/telegraf/plugins/processors/friendlytagger"' ${GOROOT}/src/github.com/influxdata/telegraf/plugins/processors/all/all.go
 
-    cd ${GOROOT}/src/github.com/influxdata/telegraf/ && make go-install
+    cd ${GOROOT}/src/github.com/influxdata/telegraf/ && make && go install -ldflags "-w -s" ./cmd/telegraf
 
 
 ### Configuration


### PR DESCRIPTION
 * Fix missing "go-install" target when building telegraf
 * Use `api.data.caida.org` for AS name lookups instead of `api,panda.caida.org`