### PR TITLE
Fixes for scripts that do not work any more

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,16 +3,16 @@ ENV GO111MODULE=auto
 RUN apk update && apk add --no-cache make git bash gcc sed build-base linux-headers
 
 WORKDIR /telegraf
+RUN mkdir -p /go/src/github.com/influxdata
+RUN git clone https://github.com/influxdata/telegraf.git /go/src/github.com/influxdata/telegraf
 
-RUN go get github.com/influxdata/telegraf
-RUN go get github.com/mattn/go-sqlite3
 COPY src /telegraf/src
 COPY helperscripts /telegraf/helperscripts
 RUN mkdir -p /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger && cp src/friendlytagger.go /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger/
 RUN sed -i '8i\        _ "github.com/influxdata/telegraf/plugins/processors/friendlytagger"' /go/src/github.com/influxdata/telegraf/plugins/processors/all/all.go
 
 RUN cd /go/src/github.com/influxdata/telegraf/ && go mod tidy && make && go install -ldflags "-w -s" ./cmd/telegraf
-RUN cd helperscripts && go build -o /go/bin/queryasnnames .
+RUN cd helperscripts && go mod tidy && go build -o /go/bin/queryasnnames .
 
 FROM alpine:latest
 RUN apk update && apk add --no-cache bash sqlite

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:alpine AS build-env
+ENV GO111MODULE=auto
 RUN apk update && apk add --no-cache make git bash gcc sed build-base linux-headers
 
 WORKDIR /telegraf
@@ -10,7 +11,7 @@ COPY helperscripts /telegraf/helperscripts
 RUN mkdir -p /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger && cp src/friendlytagger.go /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger/
 RUN sed -i '8i\        _ "github.com/influxdata/telegraf/plugins/processors/friendlytagger"' /go/src/github.com/influxdata/telegraf/plugins/processors/all/all.go
 
-RUN cd /go/src/github.com/influxdata/telegraf/ && make && go install -ldflags "-w -s" ./cmd/telegraf
+RUN cd /go/src/github.com/influxdata/telegraf/ && go mod tidy && make && go install -ldflags "-w -s" ./cmd/telegraf
 RUN cd helperscripts && go build -o /go/bin/queryasnnames .
 
 FROM alpine:latest

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ RUN git clone https://github.com/influxdata/telegraf.git /go/src/github.com/infl
 COPY src /telegraf/src
 COPY helperscripts /telegraf/helperscripts
 RUN mkdir -p /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger && cp src/friendlytagger.go /go/src/github.com/influxdata/telegraf/plugins/processors/friendlytagger/
-RUN sed -i '8i\        _ "github.com/influxdata/telegraf/plugins/processors/friendlytagger"' /go/src/github.com/influxdata/telegraf/plugins/processors/all/all.go
+
+RUN cp /telegraf/src/register_ft.go /go/src/github.com/influxdata/telegraf/plugins/processors/all/
 
 RUN cd /go/src/github.com/influxdata/telegraf/ && go mod tidy && make && go install -ldflags "-w -s" ./cmd/telegraf
 RUN cd helperscripts && go mod tidy && go build -o /go/bin/queryasnnames .

--- a/helperscripts/go.mod
+++ b/helperscripts/go.mod
@@ -1,0 +1,5 @@
+module github.com/caida/telegraf-friendlytagger/helperscripts
+  
+go 1.18
+
+require github.com/mattn/go-sqlite3 v1.14.13

--- a/helperscripts/queryasnnames.go
+++ b/helperscripts/queryasnnames.go
@@ -82,7 +82,7 @@ func LoadAsnNames(pageid int32, db *sql.DB) bool {
 
     var ctx context.Context
 
-    url := fmt.Sprintf("https://api.data.caida.org/as2org/dev/asns/?verbose=true&page=%d", pageid)
+    url := fmt.Sprintf("https://api.data.caida.org/as2org/v1/asns/?verbose=true&page=%d", pageid)
 
     client := http.Client{ Timeout: time.Second * 10}
 

--- a/src/register_ft.go
+++ b/src/register_ft.go
@@ -1,0 +1,5 @@
+//go:build !custom || processors || processors.friendlytagger
+
+package all
+
+import _ "github.com/influxdata/telegraf/plugins/processors/friendlytagger" // register plugin


### PR DESCRIPTION
Changes to golang and the AS2Org APIs mean that this container no longer works if the current `master` branch is used.

Includes fixes for:
 * Query v1 as2org API instead of dev (which no longer exists)
 * Fix go build commands for friendlytagger image